### PR TITLE
[feat] 지도 레벨 기반 마커 데이터 요청 기능 구현

### DIFF
--- a/src/components/KakaoMap.vue
+++ b/src/components/KakaoMap.vue
@@ -61,8 +61,8 @@ const watchMapInfo = () => {
     center: { lat: center.getLat(), lng: center.getLng() },
     type: mapTypeId,
     bounds: {
-      sw: { lat: swLatLng.getLat(), lng: swLatLng.getLng() },
       ne: { lat: neLatLng.getLat(), lng: neLatLng.getLng() },
+      sw: { lat: swLatLng.getLat(), lng: swLatLng.getLng() },
     },
   })
 }
@@ -89,22 +89,25 @@ const fetchAndRenderAttractions = async () => {
 
   isLoading.value = true
   errorMessage.value = ''
+
+  // 지도 정보 추가
+  const level = map.value.getLevel()
+  const mapBounds = map.value.getBounds()
+  const swLatLng = mapBounds.getSouthWest()
+  const neLatLng = mapBounds.getNorthEast()
+
   try {
-    const params = {}
+    const params = {
+      level: level.toString(),
+      swLatLng: `${swLatLng.getLat()},${swLatLng.getLng()}`,
+      neLatLng: `${neLatLng.getLat()},${neLatLng.getLng()}`,
+    }
     if (props.searchKeyword) params.keyword = props.searchKeyword
     if (props.selectedCategory) params.category = props.selectedCategory
 
-    // 지도 정보 추가
-    const level = map.value.getLevel()
-    const mapBounds = map.value.getBounds()
-    const swLatLng = mapBounds.getSouthWest()
-    const neLatLng = mapBounds.getNorthEast()
-
-    params.level = level
-    params.swLat = swLatLng.getLat()
-    params.swLng = swLatLng.getLng()
-    params.neLat = neLatLng.getLat()
-    params.neLng = neLatLng.getLng()
+    // params.level = level
+    // params.swLatLng = `${swLatLng.getLat()},${swLatLng.getLng()}`
+    // params.neLatLng = `${neLatLng.getLat()},${neLatLng.getLng()}`
 
     const response = await axios.get('/api/map', { params })
     const attractions = response.data.data.attractions

--- a/src/components/KakaoMap.vue
+++ b/src/components/KakaoMap.vue
@@ -22,6 +22,37 @@ const isLoading = ref(false)
 const errorMessage = ref('')
 const isMapReady = ref(false) // 지도 준비 여부
 
+const watchMapInfo = () => {
+  if (!map.value) return
+
+  const level = map.value.getLevel()
+  const center = map.value.getCenter()
+  const mapTypeId = map.value.getMapTypeId()
+  const bounds = map.value.getBounds()
+
+  const swLatLng = bounds.getSouthWest()
+  const neLatLng = bounds.getNorthEast()
+
+  console.log('📌 지도 정보')
+  console.log('지도 레벨:', level)
+  console.log('중심 좌표:', center.getLat(), center.getLng())
+  console.log('지도 타입:', mapTypeId)
+  console.log('영역 정보:', {
+    sw: { lat: swLatLng.getLat(), lng: swLatLng.getLng() },
+    ne: { lat: neLatLng.getLat(), lng: neLatLng.getLng() },
+  })
+
+  emit('map-info-updated', {
+    level,
+    center: { lat: center.getLat(), lng: center.getLng() },
+    type: mapTypeId,
+    bounds: {
+      sw: { lat: swLatLng.getLat(), lng: swLatLng.getLng() },
+      ne: { lat: neLatLng.getLat(), lng: neLatLng.getLng() },
+    },
+  })
+}
+
 // props 정의
 const props = defineProps({
   searchKeyword: {
@@ -121,6 +152,7 @@ onMounted(async () => {
 
     isMapReady.value = true // 지도 준비 완료
     await fetchAndRenderAttractions()
+    window.kakao.maps.event.addListener(map.value, 'idle', watchMapInfo)
   })
 })
 

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -34,6 +34,11 @@ const selectCategory = (category) => {
     searchPlaces()
   }
 }
+
+const handleMapInfo = (info) => {
+  console.log('🛰️ 부모에서 받은 지도 정보:', info)
+  // 원하는 작업: API 요청, 상태 저장, 로그 찍기 등
+}
 </script>
 
 <template>
@@ -80,6 +85,7 @@ const selectCategory = (category) => {
       :searchKeyword="searchKeyword"
       :selectedCategory="selectedCategory"
       @search-completed="handleSearchCompleted"
+      @map-info-updated="handleMapInfo"
     />
   </div>
 </template>


### PR DESCRIPTION
## 작업 내용 요약

- 지도 이동 또는 줌 레벨 변경 시, `idle` 이벤트를 통해 상태 변화 감지
- 지도 중심 좌표, 줌 레벨, 화면 영역 좌표(SW, NE)를 기반으로 관광지 마커 데이터를 요청
- GET `/api/map?level={level}&swLatLng={좌하단 좌표}&neLatLng={우상단 좌표}` 형태로 요청
- 받은 데이터를 바탕으로 지도 위에 마커 표시
- 마커 클릭 시 InfoWindow로 관광지 이름 출력

## 구현 완료 항목

| 작업 항목 | 상태 | 설명 |
|-----------|------|------|
| 지도 줌 레벨 변경 감지 | ✅ 완료 | `idle` 이벤트 리스너로 감지 |
| 지도 경계 좌표 및 레벨 추출 | ✅ 완료 | `map.getLevel()`, `getBounds()` 사용 |
| API 요청 및 파라미터 구성 | ✅ 완료 | `axios.get`을 통해 요청 구성 |
| 응답 마커 렌더링 | ✅ 완료 | `forEach`로 마커 생성 및 지도에 표시 |

## 향후 TODO

- 지도 레벨이 낮을수록 마커 개수를 제한하는 기능 추가 예정 (예: level 3이면 최대 10개만)
- 지도 타입(mapTypeId) 활용 등 시각적 변화 대응 고려

## 관련 이슈

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 지도 상태(확대/축소 레벨, 중심 좌표, 지도 유형, 보이는 영역 정보 등)를 실시간으로 추적하여 새로운 이벤트(`map-info-updated`)로 제공합니다.
  - 지도 뷰포트(경계 좌표, 줌 레벨) 정보를 포함하여 관광지 검색이 더욱 정밀하게 이루어집니다.

- **기타**
  - 지도 이벤트 및 마커 관련 내부 변수 명칭이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->