### PR TITLE
[feat] 비로그인 상태에서 헤더 메뉴 접근 시 로그인 페이지로 이동 (#6)

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -11,9 +11,15 @@
 
       <!-- 내비게이션 -->
       <nav class="hidden md:flex gap-6">
-        <RouterLink to="/map" class="text-white hover:underline">지도보기</RouterLink>
-        <RouterLink to="/posts" class="text-white hover:underline">게시글 보기</RouterLink>
-        <RouterLink to="/notice" class="text-white hover:underline">공지사항</RouterLink>
+        <span @click="navigateWithAuth('/map')" class="text-white hover:underline cursor-pointer"
+          >지도보기</span
+        >
+        <span @click="navigateWithAuth('/posts')" class="text-white hover:underline cursor-pointer"
+          >게시글 보기</span
+        >
+        <span @click="navigateWithAuth('/notice')" class="text-white hover:underline cursor-pointer"
+          >공지사항</span
+        >
       </nav>
 
       <!-- 로그인 상태에 따른 버튼 -->
@@ -21,7 +27,7 @@
         <span class="text-white font-semibold">{{ nickname }}님! 반가워요!</span>
         <button
           class="border-2 border-white text-white px-4 py-1 rounded hover:bg-white hover:text-blue-600 transition"
-          @click="goProfile"
+          @click="navigateWithAuth('/profile')"
         >
           마이페이지
         </button>
@@ -62,5 +68,13 @@ const handleLogout = () => {
   userStore.logout()
   router.push('/')
   location.reload()
+}
+
+const navigateWithAuth = (path) => {
+  if (!isLoggedIn.value) {
+    router.push('/login')
+  } else {
+    router.push(path)
+  }
 }
 </script>


### PR DESCRIPTION
## 구현 내용

비로그인 상태에서 상단 헤더 메뉴(지도보기 / 게시글 보기 / 공지사항 / 마이페이지 등)를 클릭했을 때, 로그인 페이지(`/login`)로 자동 이동되도록 기능을 추가했습니다.

- `isLoggedIn` 상태를 기준으로 접근 제어
- `RouterLink` 대신 `navigateWithAuth` 커스텀 함수로 동적 라우팅 처리
- 사용자 경험 향상을 위해 이벤트 바인딩 시 인증 여부 검사 추가

## 접근 제어 방식

- accessToken 존재 여부 확인 → 인증 상태 판단
- 인증되지 않은 경우 모든 헤더 메뉴 접근 시 `/login` 페이지로 리디렉션
- 인증된 경우 기존과 동일하게 정상 이동

## 테스트 방법

- [x] 로그아웃 후 헤더 메뉴 클릭 시 로그인 페이지로 이동하는지 확인
- [x] 로그인 상태일 때 정상적으로 페이지 이동이 되는지 확인

## 관련 이슈

- close #6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 로그인 상태에 따라 내비게이션 링크 클릭 시 로그인 페이지 또는 해당 경로로 이동하도록 동작이 개선되었습니다.  
- **버그 수정**
  - "마이페이지" 버튼 클릭 시 로그인 여부에 따라 올바른 경로로 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->