### PR TITLE
feat: 새로고침 버튼 클릭 시에만 마커 데이터 요청 기능 구현 (#8)

### DIFF
--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -44,7 +44,6 @@ const handleMapInfo = (info) => {
 const kakaoMapRef = ref(null)
 
 const requestMarkers = async () => {
-  console.log('fsadsadfsf')
   if (!latestMapInfo.value) return
 
   const { level, bounds } = latestMapInfo.value
@@ -59,11 +58,13 @@ const requestMarkers = async () => {
     category: selectedCategory.value,
   }
 
-  const response = await axios.get('/api/map', { params })
-  const attractions = response.data.data.attractions
-
-  // ✅ KakaoMap 내부 마커 렌더링 함수 호출
-  kakaoMapRef.value?.renderAttractions(attractions)
+  try {
+    const { data } = await axios.get('/api/map', { params })
+    const attractions = data.data.attractions
+    kakaoMapRef.value?.renderAttractions(attractions)
+  } catch (err) {
+    console.error('마커 데이터 요청 실패:', err)
+  }
 }
 </script>
 

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -1,9 +1,10 @@
 <script setup>
 import { ref, reactive } from 'vue'
 import KakaoMap from '@/components/KakaoMap.vue'
-
+import axios from '@/api/axios'
 const searchKeyword = ref('')
 const selectedCategory = ref(null)
+const latestMapInfo = ref(null) // watchMapInfo에서 전달된 최신 정보 저장
 
 const categories = reactive([
   { id: 'A01', name: '자연', icon: '🌳' },
@@ -36,8 +37,33 @@ const selectCategory = (category) => {
 }
 
 const handleMapInfo = (info) => {
-  console.log('🛰️ 부모에서 받은 지도 정보:', info)
-  // 원하는 작업: API 요청, 상태 저장, 로그 찍기 등
+  latestMapInfo.value = info
+  console.log('📍 지도 정보 저장됨:', info)
+}
+
+const kakaoMapRef = ref(null)
+
+const requestMarkers = async () => {
+  console.log('fsadsadfsf')
+  if (!latestMapInfo.value) return
+
+  const { level, bounds } = latestMapInfo.value
+  const sw = bounds.sw
+  const ne = bounds.ne
+
+  const params = {
+    level: level.toString(),
+    swLatLng: `${sw.lat},${sw.lng}`,
+    neLatLng: `${ne.lat},${ne.lng}`,
+    keyword: searchKeyword.value,
+    category: selectedCategory.value,
+  }
+
+  const response = await axios.get('/api/map', { params })
+  const attractions = response.data.data.attractions
+
+  // ✅ KakaoMap 내부 마커 렌더링 함수 호출
+  kakaoMapRef.value?.renderAttractions(attractions)
 }
 </script>
 
@@ -82,11 +108,18 @@ const handleMapInfo = (info) => {
     이로 인해 검색어나 카테고리 선택이 지도에 반영되지 않을 수 있습니다.
     컴포넌트 간 데이터 흐름을 설정하여 사용자 입력이 지도에 반영되도록 하세요.-->
     <KakaoMap
+      ref="kakaoMapRef"
       :searchKeyword="searchKeyword"
       :selectedCategory="selectedCategory"
-      @search-completed="handleSearchCompleted"
       @map-info-updated="handleMapInfo"
     />
+
+    <button
+      class="absolute bottom-6 left-1/2 transform -translate-x-1/2 bg-blue-500 text-white px-6 py-2 rounded shadow hover:bg-blue-600 z-20"
+      @click="requestMarkers"
+    >
+      새로고침
+    </button>
   </div>
 </template>
 


### PR DESCRIPTION
## 📌 구현 개요

기존에는 지도 이동 또는 줌 변경 시 자동으로 마커 데이터 요청이 발생했으나,  
이번 커밋에서는 **"중앙 하단 새로고침 버튼"을 클릭했을 때만** 마커 데이터를 요청하도록 동작 방식을 변경했습니다.

## 🔧 주요 변경 사항

### KakaoMap.vue
- `watchMapInfo()` 함수에서 현재 위치, 줌 레벨, 좌표 계산
- 계산된 값은 `emit`으로 전달만 하고 마커 요청은 수행하지 않음

### Map.vue
- `@map-info-updated` 이벤트로 받은 데이터를 로컬 변수에 저장
- **"새로고침" 버튼 클릭 시** 해당 데이터로 API 호출하여 마커 데이터를 요청
- 요청 결과에 따라 마커 렌더링 수행

## 🧪 테스트 체크리스트

- [x] 지도 이동/확대만으로는 마커가 요청되지 않는지 확인
- [x] 새로고침 버튼 클릭 시 정확한 마커 요청 및 렌더링이 이루어지는지 확인
- [x] 데이터 요청 중복 없이 명확한 타이밍에만 실행되는지 확인

## 🔗 관련 이슈

- close #8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 지도 아래에 "새로고침" 버튼이 추가되어, 현재 지도 위치와 검색 조건에 따라 최신 명소 마커를 불러올 수 있습니다.

- **기능 개선**
  - 지도 마커 렌더링 기능이 외부에서 직접 호출 가능하도록 개선되어, 명소 데이터를 받아 지도에 표시할 수 있습니다.
  - 내부 데이터 fetching 및 렌더링 로직이 분리되어 유연성이 향상되었습니다.

- **버그 수정**
  - 불필요한 디버그 로그가 제거되어 콘솔이 깔끔해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->