### PR TITLE
[fix] 새로고침 시 지도 줌 레벨이 초기화되는 버그 수정 (#10)

### DIFF
--- a/src/components/KakaoMap.vue
+++ b/src/components/KakaoMap.vue
@@ -62,10 +62,6 @@ const renderAttractions = (attractions) => {
     kakaoMarkers.value.push(marker)
     markerBounds.extend(position)
   })
-
-  if (attractions.length > 1) {
-    map.value.setBounds(markerBounds)
-  }
 }
 
 // 🌐 외부에서 renderAttractions 호출 가능하게 노출

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -119,7 +119,7 @@ const requestMarkers = async () => {
       class="absolute bottom-6 left-1/2 transform -translate-x-1/2 bg-blue-500 text-white px-6 py-2 rounded shadow hover:bg-blue-600 z-20"
       @click="requestMarkers"
     >
-      새로고침
+      현 지도에서 검색
     </button>
   </div>
 </template>


### PR DESCRIPTION
## 🐞 문제 요약

새로고침 버튼을 클릭할 때마다 지도 줌 레벨이 초기화되거나 의도치 않게 변경되는 문제가 발생했습니다.  
이는 마커 데이터를 요청하면서 내부적으로 `setLevel()`이 호출되거나, 상태가 리셋되는 흐름 때문이었습니다.

## 🔧 주요 수정 사항

- 마커 요청 로직에서 줌 레벨 변경과 관련된 처리 제거
- 현재 지도 상태(레벨, 중심 좌표 등)를 유지한 채 마커 데이터만 새로 요청
- 새로고침 시에도 사용자가 조작한 줌 레벨이 그대로 유지되도록 개선

## ✅ 테스트 체크리스트

- [x] 줌 레벨을 조정한 후 새로고침 시 줌 상태가 유지되는지 확인
- [x] 새로고침 시 마커만 새로 갱신되고 지도의 상태는 유지되는지 확인
- [x] 불필요한 렌더링이나 상태 초기화가 발생하지 않는지 확인

## 🔗 관련 이슈

- close #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 여러 명소가 있을 때 지도 영역이 자동으로 조정되지 않도록 변경되었습니다.

- **스타일**
  - 지도 화면의 버튼 라벨이 "새로고침"에서 "현 지도에서 검색"으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->