### PR TITLE
[feat] 장소 리스트 컴포넌트 구현 및 지도와 연동 (#14)

### DIFF
--- a/src/components/KakaoMap.vue
+++ b/src/components/KakaoMap.vue
@@ -90,10 +90,12 @@ const openOverlay = (marker, item) => {
 
   const closeBtn = content.querySelector('.close')
   if (closeBtn) {
-    closeBtn.addEventListener('click', () => {
+    const closeHandler = () => {
+      closeBtn.removeEventListener('click', closeHandler)
       sharedOverlay.setMap(null)
       sharedOverlay = null
-    })
+    }
+    closeBtn.addEventListener('click', closeHandler)
   }
 }
 

--- a/src/components/KakaoMap.vue
+++ b/src/components/KakaoMap.vue
@@ -205,6 +205,15 @@ watch(
   { deep: true }
 )
 
+watch(
+  () => props.selectedContentId,
+  (newContentId) => {
+    if (newContentId && isMapReady.value) {
+      focusMarker(newContentId)
+    }
+  }
+)
+
 onUnmounted(() => {
   kakaoMarkers.value.forEach((marker) => marker.setMap(null))
 })
@@ -264,11 +273,6 @@ onUnmounted(() => {
   position: relative;
   z-index: 1000;
 }
-.attraction-item.active {
-  background-color: #e6f2ff;
-  border-left: 4px solid #2196f3;
-}
-
 .wrap * {
   padding: 0;
   margin: 0;

--- a/src/components/KakaoMap.vue
+++ b/src/components/KakaoMap.vue
@@ -14,6 +14,9 @@
 import { ref, onMounted, onUnmounted, watch } from 'vue'
 import axios from '@/api/axios'
 
+const markerMap = new Map() // contentId → marker 객체
+const attractionMap = new Map() // contentId → attraction 데이터
+
 const mapContainer = ref(null)
 const map = ref(null)
 const kakaoMarkers = ref([])
@@ -25,12 +28,12 @@ const isMapReady = ref(false)
 const props = defineProps({
   searchKeyword: { type: String, default: '' },
   selectedCategory: { type: String, default: null },
+  selectedContentId: { type: Number, default: null },
 })
 
 const emit = defineEmits(['search-completed', 'map-info-updated'])
 let sharedOverlay = null
 
-// 간단한 이스케이프 유틸
 function escapeHTML(str) {
   return str
     .replace(/&/g, '&amp;')
@@ -41,7 +44,6 @@ function escapeHTML(str) {
 }
 
 function wrapText(text, maxLength = 20) {
-  // 잠재적 스크립트 삽입 방지를 위해 HTML 인코딩
   const words = escapeHTML(text).split(' ')
   let result = ''
   let line = ''
@@ -55,6 +57,46 @@ function wrapText(text, maxLength = 20) {
   return result + line.trim()
 }
 
+const openOverlay = (marker, item) => {
+  if (sharedOverlay) sharedOverlay.setMap(null)
+
+  const content = document.createElement('div')
+  content.className = 'wrap'
+  content.innerHTML = `
+    <div class="info">
+      <div class="title">
+        ${wrapText(escapeHTML(item.title))}
+        <div class="close" title="닫기"></div>
+      </div>
+      <div class="body">
+        <div class="img">
+          <img src="${item.firstImage || 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/thumnail.png'}" width="73" height="70">
+        </div>
+        <div class="desc">
+          <div class="ellipsis">${wrapText(escapeHTML(item.address))}</div>
+          ${item.tel ? `<div class="jibun ellipsis">${item.tel}</div>` : ''}
+        </div>
+      </div>
+    </div>
+  `
+
+  sharedOverlay = new kakao.maps.CustomOverlay({
+    content,
+    map: map.value,
+    position: marker.getPosition(),
+    xAnchor: 0.5,
+    yAnchor: 1.4,
+  })
+
+  const closeBtn = content.querySelector('.close')
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => {
+      sharedOverlay.setMap(null)
+      sharedOverlay = null
+    })
+  }
+}
+
 const renderAttractions = (attractions) => {
   if (!map.value) return
 
@@ -65,6 +107,8 @@ const renderAttractions = (attractions) => {
 
   kakaoMarkers.value.forEach((marker) => marker.setMap(null))
   kakaoMarkers.value = []
+  markerMap.clear()
+  attractionMap.clear()
 
   const markerBounds = new window.kakao.maps.LatLngBounds()
   const imageSrc = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png'
@@ -82,57 +126,32 @@ const renderAttractions = (attractions) => {
     })
 
     kakao.maps.event.addListener(marker, 'click', () => {
-      if (sharedOverlay) {
-        sharedOverlay.setMap(null)
-      }
-
-      const content = document.createElement('div')
-      content.className = 'wrap'
-      content.innerHTML = `
-        <div class="info">
-          <div class="title">
-            ${wrapText(escapeHTML(item.title))}
-            <div class="close" title="닫기"></div>
-          </div>
-          <div class="body">
-            <div class="img">
-              <img src="${item.firstImage || 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/thumnail.png'}" width="73" height="70">
-            </div>
-            <div class="desc">
-              <div class="ellipsis">${wrapText(escapeHTML(item.address))}</div>
-              ${item.tel ? `<div class="jibun ellipsis">${item.tel}</div>` : ''}
-            </div>
-          </div>
-        </div>
-      `
-
-      sharedOverlay = new kakao.maps.CustomOverlay({
-        content,
-        map: map.value,
-        position: marker.getPosition(),
-        xAnchor: 0.5,
-        yAnchor: 1.4,
-      })
-
-      const closeBtn = content.querySelector('.close')
-      if (closeBtn) {
-        closeBtn.addEventListener('click', () => {
-          sharedOverlay.setMap(null)
-          sharedOverlay = null
-        })
-      }
+      openOverlay(marker, item)
     })
 
     kakaoMarkers.value.push(marker)
+    markerMap.set(item.contentId, marker)
+    attractionMap.set(item.contentId, item)
     markerBounds.extend(position)
   })
 }
 
-defineExpose({ renderAttractions })
+const focusMarker = (contentId) => {
+  if (!map.value || !markerMap.has(contentId)) return
+  kakaoMarkers.value.forEach((m) => m.setMap(null))
+  const marker = markerMap.get(contentId)
+  const item = attractionMap.get(contentId)
+  if (marker && item) {
+    marker.setMap(map.value)
+    map.value.setCenter(marker.getPosition())
+    openOverlay(marker, item)
+  }
+}
+
+defineExpose({ renderAttractions, focusMarker })
 
 const watchMapInfo = () => {
   if (!map.value) return
-
   const level = map.value.getLevel()
   const center = map.value.getCenter()
   const mapTypeId = map.value.getMapTypeId()
@@ -168,13 +187,11 @@ const loadKakaoMapsScript = () => {
 
 onMounted(async () => {
   await loadKakaoMapsScript()
-
   window.kakao.maps.load(() => {
     map.value = new window.kakao.maps.Map(mapContainer.value, {
       center: new window.kakao.maps.LatLng(37.5014, 127.0394),
       level: 11,
     })
-
     isMapReady.value = true
     window.kakao.maps.event.addListener(map.value, 'idle', watchMapInfo)
   })
@@ -247,6 +264,11 @@ onUnmounted(() => {
   position: relative;
   z-index: 1000;
 }
+.attraction-item.active {
+  background-color: #e6f2ff;
+  border-left: 4px solid #2196f3;
+}
+
 .wrap * {
   padding: 0;
   margin: 0;

--- a/src/components/KakaoMap.vue
+++ b/src/components/KakaoMap.vue
@@ -58,6 +58,11 @@ function wrapText(text, maxLength = 20) {
 const renderAttractions = (attractions) => {
   if (!map.value) return
 
+  if (sharedOverlay) {
+    sharedOverlay.setMap(null)
+    sharedOverlay = null
+  }
+
   kakaoMarkers.value.forEach((marker) => marker.setMap(null))
   kakaoMarkers.value = []
 

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -72,7 +72,10 @@ const requestMarkers = async () => {
     console.error('마커 데이터 요청 실패:', err)
   }
 }
+const selectedContentId = ref(null)
+
 const onAttractionClick = (attraction) => {
+  selectedContentId.value = attraction.contentId
   kakaoMapRef.value?.focusMarker(attraction.contentId)
 }
 </script>
@@ -130,12 +133,19 @@ const onAttractionClick = (attraction) => {
         v-for="item in attractionList"
         :key="item.contentId"
         class="attraction-item"
+        :class="{ active: selectedContentId === item.contentId }"
+        @click="onAttractionClick(item)"
+      >
+        <!-- <div
+        v-for="item in attractionList"
+        :key="item.contentId"
+        class="attraction-item"
         @click="onAttractionClick(item)"
         tabindex="0"
         @keyup.enter="onAttractionClick(item)"
         role="button"
         :aria-label="`${item.title} 장소 선택`"
-      >
+      > -->
         <img
           :src="
             item.firstImage ||

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -314,6 +314,11 @@ const onAttractionClick = (attraction) => {
   border-bottom: 1px solid #eee;
 }
 
+.attraction-item.active {
+  background-color: #e6f2ff;
+  border-left: 4px solid #2196f3;
+}
+
 .attraction-item:last-child {
   border-bottom: none;
 }

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -72,6 +72,9 @@ const requestMarkers = async () => {
     console.error('마커 데이터 요청 실패:', err)
   }
 }
+const onAttractionClick = (attraction) => {
+  kakaoMapRef.value?.focusMarker(attraction.contentId)
+}
 </script>
 
 <template>
@@ -123,7 +126,16 @@ const requestMarkers = async () => {
     />
 
     <div class="attraction-list">
-      <div v-for="item in attractionList" :key="item.contentId" class="attraction-item">
+      <div
+        v-for="item in attractionList"
+        :key="item.contentId"
+        class="attraction-item"
+        @click="onAttractionClick(item)"
+        tabindex="0"
+        @keyup.enter="onAttractionClick(item)"
+        role="button"
+        :aria-label="`${item.title} 장소 선택`"
+      >
         <img
           :src="
             item.firstImage ||
@@ -268,6 +280,18 @@ const requestMarkers = async () => {
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   z-index: 11;
+}
+
+@media (max-width: 768px) {
+  .attraction-list {
+    width: calc(100vw - 20px);
+    max-width: 400px;
+  }
+
+  .search-box {
+    width: calc(100vw - 20px);
+    max-width: 400px;
+  }
 }
 
 .attraction-item {

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -42,6 +42,11 @@ const handleMapInfo = (info) => {
 }
 
 const kakaoMapRef = ref(null)
+const attractionList = ref([])
+
+const updateAttractions = (items) => {
+  attractionList.value = items
+}
 
 const requestMarkers = async () => {
   if (!latestMapInfo.value) return
@@ -62,6 +67,7 @@ const requestMarkers = async () => {
     const { data } = await axios.get('/api/map', { params })
     const attractions = data.data.attractions
     kakaoMapRef.value?.renderAttractions(attractions)
+    updateAttractions(attractions)
   } catch (err) {
     console.error('마커 데이터 요청 실패:', err)
   }
@@ -113,7 +119,25 @@ const requestMarkers = async () => {
       :searchKeyword="searchKeyword"
       :selectedCategory="selectedCategory"
       @map-info-updated="handleMapInfo"
+      @search-completed="updateAttractions"
     />
+
+    <div class="attraction-list">
+      <div v-for="item in attractionList" :key="item.contentId" class="attraction-item">
+        <img
+          :src="
+            item.firstImage ||
+            'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/thumnail.png'
+          "
+          class="attraction-thumbnail"
+        />
+        <div class="attraction-info">
+          <strong>{{ item.title }}</strong
+          ><br />
+          <small>{{ item.address }}</small>
+        </div>
+      </div>
+    </div>
 
     <button
       class="absolute bottom-6 left-1/2 transform -translate-x-1/2 bg-blue-500 text-white px-6 py-2 rounded shadow hover:bg-blue-600 z-20"
@@ -232,5 +256,45 @@ const requestMarkers = async () => {
 .category-name {
   font-size: 12px;
   white-space: nowrap;
+}
+.attraction-list {
+  position: absolute;
+  top: 170px; /* 검색창 아래로 살짝 내림 */
+  left: 10px;
+  width: 400px;
+  max-height: 1000px;
+  overflow-y: auto;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  z-index: 11;
+}
+
+.attraction-item {
+  display: flex;
+  align-items: center;
+  height: 120px;
+  padding: 10px;
+  padding-left: 20px;
+  gap: 10px;
+  border-bottom: 1px solid #eee;
+}
+
+.attraction-item:last-child {
+  border-bottom: none;
+}
+
+.attraction-thumbnail {
+  width: 75px;
+  height: 75px;
+  border-radius: 6px;
+  object-fit: cover;
+  flex-shrink: 0;
+  border: 1px solid #ddd;
+}
+
+.attraction-info {
+  flex: 1;
+  font-size: 16px;
 }
 </style>


### PR DESCRIPTION
## ✨ 기능 개요

지도 오른쪽에 장소 리스트 컴포넌트를 구현하고, 지도에 표시되는 마커와 연동되도록 설정했습니다.  
장소 리스트와 마커 간 상호작용이 가능하도록 구현하여 사용자의 탐색 편의성을 향상시켰습니다.

---

## 🛠 주요 구현 내용

### 📋 장소 리스트 컴포넌트
- 장소 목록 데이터 배열을 props로 받아 리스트 렌더링
- 장소명, 주소, 요약 정보 등의 정보 표시

### 🗺 지도 마커와 연동
- 반대로 마커 클릭 시 해당 리스트 항목 하이라이트 처리 가능 구현

---

## 📎 관련 이슈

- close #14


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 지도 아래에 관광지 목록 패널이 추가되어, 검색 결과에 따라 썸네일, 제목, 주소가 표시됩니다.
  - 관광지 목록의 항목을 클릭하면 해당 마커로 지도가 포커스됩니다.
  - 검색 완료 시 관광지 목록이 자동으로 업데이트됩니다.
  - 지도 마커 클릭 시 오버레이가 통합 관리되고, 선택된 마커만 보여지는 기능이 추가되었습니다.

- **스타일**
  - 관광지 목록 패널의 위치, 스크롤, 항목 레이아웃, 이미지 스타일이 개선되었습니다.
  - 활성화된 관광지 항목에 대한 스타일이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->