### PR TITLE
fix: 로그아웃 시 실제 로그아웃 API 호출하도록 수정

### DIFF
--- a/src/api/services/userService.js
+++ b/src/api/services/userService.js
@@ -1,14 +1,28 @@
+// src/api/services/userService.js
 import axios from '@/api/axios'
+import { useUserStore } from '@/stores/user'
 
 export const userService = {
-  // 사용자 정보 가져오기
-  getUserInfo() {
-    return axios.get('/user/info') // 이 URL은 실제 백엔드 API에 맞게 수정해야 함
+  async getUserInfo() {
+    return axios.get('/user/info') // 필요한 경우 실제 API로 수정
   },
 
-  // 로그아웃 처리 (단순 로컬스토리지 삭제)
-  logout() {
-    localStorage.removeItem('accessToken')
-    localStorage.removeItem('refreshToken')
+  async logout() {
+    const userStore = useUserStore()
+
+    try {
+      await axios.post('/api/auth/logout', null, {
+        headers: {
+          Authorization: `Bearer ${userStore.token}`,
+        },
+      })
+    } catch (err) {
+      console.error('🔴 서버 로그아웃 실패:', err)
+      throw err
+    } finally {
+      localStorage.removeItem('accessToken')
+      localStorage.removeItem('refreshToken')
+      userStore.logout()
+    }
   },
 }

--- a/src/api/services/userService.js
+++ b/src/api/services/userService.js
@@ -16,13 +16,13 @@ export const userService = {
           Authorization: `Bearer ${userStore.token}`,
         },
       })
-    } catch (err) {
-      console.error('🔴 서버 로그아웃 실패:', err)
-      throw err
-    } finally {
+      // API 성공 시에만 토큰 제거
       localStorage.removeItem('accessToken')
       localStorage.removeItem('refreshToken')
       userStore.logout()
+    } catch (err) {
+      console.error('🔴 서버 로그아웃 실패:', err)
+      throw err
     }
   },
 }

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -98,6 +98,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { useUserStore } from '@/stores/user'
+import { userService } from '@/api/services/userService'
 
 // prop으로 강제 라이트 모드 사용 여부 전달
 const props = defineProps({
@@ -137,8 +138,12 @@ const navigateWithAuth = (path) => {
   if (!isLoggedIn.value) router.push('/login')
   else router.push(path)
 }
-const handleLogout = () => {
-  userStore.logout()
-  router.push('/')
+const handleLogout = async () => {
+  try {
+    await userService.logout()
+    router.push('/login')
+  } catch {
+    alert('로그아웃 중 문제가 발생했습니다.')
+  }
 }
 </script>


### PR DESCRIPTION
## 🔧 수정 개요

기존에는 로그아웃 시 `localStorage`에서 accessToken만 제거하고, 실제 서버 로그아웃 API 호출이 이루어지지 않았습니다.  
이 PR에서는 로그아웃 시 먼저 API를 호출하고, 응답 성공 시 로컬 토큰을 제거하도록 인증 흐름을 수정하였습니다.

---

## 🛠 주요 수정 사항

- 로그아웃 시 `/api/auth/logout` API를 호출하도록 변경
- API 호출 성공 시에만 localStorage에서 accessToken 삭제
- 로그아웃 후 로그인 페이지(`/login`)로 리디렉션 처리
- 네트워크 오류 발생 시 사용자에게 안내 메시지 표시 추가

---

## ✅ 테스트 체크리스트

- [x] 로그아웃 버튼 클릭 시 실제 API 호출 여부 확인
- [x] API 응답이 성공일 경우에만 localStorage 초기화되는지 확인
- [x] 실패 시 알림 또는 예외 처리 UI 정상 동작 확인
- [x] 로그아웃 후 로그인 화면으로 잘 이동되는지 확인

---

## 📎 관련 이슈

- close #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 로그아웃 시 서버와의 통신을 통해 로그아웃이 처리되며, 실패 시 오류 메시지가 표시됩니다.
  - 로그아웃 후 홈 화면이 아닌 로그인 페이지로 이동하도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->