### PR TITLE
refactor: 코드레빗 PR 리뷰 반영-2 (feat/9-logout-api-call)

### DIFF
--- a/src/api/services/userService.js
+++ b/src/api/services/userService.js
@@ -3,7 +3,7 @@ import axios from '@/api/axios'
 import { useUserStore } from '@/stores/user'
 
 export const userService = {
-  async getUserInfo() {
+  getUserInfo() {
     return axios.get('/user/info') // 필요한 경우 실제 API로 수정
   },
 
@@ -13,12 +13,11 @@ export const userService = {
     try {
       await axios.post('/api/auth/logout', null, {
         headers: {
-          Authorization: `Bearer ${userStore.token}`,
+          Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
         },
       })
       // API 성공 시에만 토큰 제거
       localStorage.removeItem('accessToken')
-      localStorage.removeItem('refreshToken')
       userStore.logout()
     } catch (err) {
       console.error('🔴 서버 로그아웃 실패:', err)

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -15,6 +15,7 @@ export const useUserStore = defineStore('user', () => {
 
   const logout = () => {
     localStorage.removeItem('accessToken')
+    localStorage.removeItem('refreshToken')
     localStorage.removeItem('nickname')
 
     isLoggedIn.value = false


### PR DESCRIPTION
## 🛠 코드레빗 리뷰 반영 - 2차

로그아웃 및 사용자 정보 API와 관련된 코드레빗 리뷰 내용을 반영하여 다음과 같은 리팩토링을 진행했습니다.  
토큰 접근 방식과 메서드 정리, 토큰 관리 일관성, 코드 정리 등을 중심으로 수정하였습니다.

---

### 🔧 주요 반영 사항

#### 1. `userService.logout` 내 토큰 접근 방식 수정
- ❌ `userStore.token` → ✅ `localStorage.getItem('accessToken')`  
  userStore에 `token` 속성이 없기 때문에 직접 localStorage에서 accessToken을 가져오도록 수정

#### 2. `refreshToken` 처리 일관성 확보
- 기존: `userService`에서만 `refreshToken` 제거
- 수정: `userStore.logout()`에서도 `refreshToken`을 제거하도록 수정 → 관리 책임 일치

#### 3. `getUserInfo` 함수 async 키워드 정리
- 내부에서 `await` 없이 `axios.get()`만 사용하는 경우 `async` 제거
- 또는 `await`을 활용하여 `response.data`만 반환하도록 명확화

---

### 🗂 변경 파일 요약

| 파일 경로                             | 변경 요약 |
|--------------------------------------|-----------|
| `src/api/services/userService.js`    | `logout`, `getUserInfo` 메서드 리팩토링 |
| `src/components/Header.vue`          | 로그아웃 흐름 정리, 실패 시 안내 메시지 표시 |
| `src/stores/user.js`                 | `logout()`에서 `refreshToken` 제거 추가 |

---

### ✅ 리뷰 기반 테스트 체크리스트

- [x] 로그아웃 시 accessToken, refreshToken 모두 정상 삭제
- [x] 로그아웃 API 호출 시 토큰이 정상적으로 포함되는지 확인
- [x] getUserInfo 함수의 응답 구조 일관성 확보
- [x] 콘솔 에러 없이 Header에서 로그아웃 동작 확인

---

### 📎 관련 이슈

- 관련 브랜치: `feat/9-logout-api-call`
- 관련 이슈: 연동 완료됨


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 로그아웃 시 이제 accessToken과 refreshToken이 모두 정상적으로 삭제됩니다.
- **기타**
  - 사용자 정보 요청 처리 방식이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->