### PR TITLE
[fix] 지도 초기화 중 null 오류 방지 및 마커 렌더링 안정성 향상

### DIFF
--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -37,10 +37,10 @@ const selectCategory = (category) => {
 }
 
 const handleMapInfo = (info) => {
+  if (!info || !info.bounds || !info.bounds.sw || !info.bounds.ne) return
   latestMapInfo.value = info
   console.log('📍 지도 정보 저장됨:', info)
 }
-
 const kakaoMapRef = ref(null)
 const attractionList = ref([])
 


### PR DESCRIPTION
## 🐞 문제 개요

지도 초기화 또는 렌더링 중 `null` 객체에 접근하여 발생하는 오류(`Cannot read properties of null (reading 'Xe')`)가 확인되었습니다.  
이는 카카오맵 객체나 지도 인스턴스가 아직 준비되지 않은 상태에서 마커를 렌더링하거나 이벤트를 등록하려 할 때 자주 발생합니다.

---

## 🔧 주요 수정 사항

- `map.value`, `window.kakao.maps` 존재 여부를 체크한 뒤 안전하게 접근하도록 수정
- `onMounted()` 시점 이전에는 마커 렌더링 또는 중심 좌표 접근을 하지 않도록 예외 처리
- 마커 렌더링 관련 로직에 debounce 적용 (`bounds_changed` 이벤트 과도한 호출 방지)
- `onUnmounted()` 훅에서 이벤트 리스너 제거 및 `map.value = null` 처리로 리소스 정리

---

## ✅ 테스트 체크리스트

- [x] 초기 로딩 중 오류 없이 지도와 마커가 정상적으로 렌더링되는지 확인
- [x] 빠르게 확대/축소하거나 bounds를 이동해도 오류 없이 안정적으로 동작하는지 확인
- [x] 컴포넌트가 언마운트될 때 리스너와 map 인스턴스가 정상적으로 해제되는지 확인

---

## 📎 관련 이슈

#21 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 지도 정보 및 범위가 올바르게 로드되지 않을 때 발생할 수 있는 오류를 방지하여 지도 컴포넌트의 안정성을 향상시켰습니다.
  - 지도 이벤트 리스너가 컴포넌트 해제 시 정상적으로 제거되어 불필요한 동작이 발생하지 않도록 개선했습니다.
  - 지도 정보가 불완전할 경우 지도 정보 갱신이 이루어지지 않도록 처리하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->