### PR TITLE
chore: 배포 환경에 맞춰 VITE_API_URL을 새 API 서버 IP로 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,20 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>여기저기 - 여행 계획 및 추천</title>
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap"
-    />
-    <link rel="icon" href="/favicon.ico" />
-    <meta
-      name="description"
-      content="여기저기에서 다양한 여행 계획을 세우고 추천 여행지를 찾아보세요."
-    />
-    <script
-      type="text/javascript"
-      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=bb5d6fc6d618636cf6cd5284ff93aaba"
-    ></script>
+    <title>여기저기</title>
+    <link href="https://fonts.googleapis.com/css2?family=Do+Hyeon&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="app"></div>

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -2,7 +2,7 @@ import axios from 'axios'
 
 // API 기본 설정
 const instance = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://70.12.60.56:8080',
+  baseURL: import.meta.env.VITE_API_URL,
   timeout: 10000,
   withCredentials: true,
   headers: {

--- a/src/api/services/userAuthService.js
+++ b/src/api/services/userAuthService.js
@@ -28,13 +28,18 @@ class UserAuthService {
    */
   async login(credentials) {
     try {
-      const response = await axios.post('/api/auth/login', credentials)
+
+const response = await instance.post('/auth/login', credentials)
+        credentials,
+        { withCredentials: true } // 이거 꼭 추가
+      )
+
       const { accessToken = '', refreshToken = '', nickname = '' } = response.data || {}
 
       if (accessToken) {
         localStorage.setItem('accessToken', accessToken)
         localStorage.setItem('refreshToken', refreshToken)
-        localStorage.setItem('nickname', nickname) // ← 닉네임도 저장
+        localStorage.setItem('nickname', nickname)
       }
 
       return response.data

--- a/src/api/services/userAuthService.js
+++ b/src/api/services/userAuthService.js
@@ -28,11 +28,7 @@ class UserAuthService {
    */
   async login(credentials) {
     try {
-
-const response = await instance.post('/auth/login', credentials)
-        credentials,
-        { withCredentials: true } // 이거 꼭 추가
-      )
+      const response = await axios.post('/api/auth/login', credentials)
 
       const { accessToken = '', refreshToken = '', nickname = '' } = response.data || {}
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,8 +16,9 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: process.env.VITE_API_URL || 'http://70.12.60.56:8080',
+        target: process.env.VITE_API_URL,
         changeOrigin: true,
+        secure: false,
         rewrite: (path) => path.replace(/^\/api/, ''),
       },
     },

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,7 +16,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: process.env.VITE_API_URL,
+        target: import.meta.env.VITE_API_URL,
         changeOrigin: true,
         secure: false,
         rewrite: (path) => path.replace(/^\/api/, ''),


### PR DESCRIPTION
## 📦 변경 내용

- .env 파일의 `VITE_API_URL` 값을 배포용 API 서버 주소로 수정
- 배포 시 axios 요청이 정확한 서버로 전송되도록 환경 설정 정리
- 개발 환경에서는 기존 프록시 설정 유지하여 로컬 개발 가능하도록 구성

---

## ✅ 테스트 체크리스트

- [x] 배포 후 axios 요청이 새 IP로 정상 동작하는지 확인
- [x] 로컬 개발 환경에서 기존 기능 정상 작동 여부 확인
- [x] 콘솔 로그로 baseURL 확인 (`console.log(import.meta.env.VITE_API_URL)`)

---

## 🔗 관련 이슈

- close #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **스타일**
	- 페이지 제목이 간단하게 변경되고, 폰트가 "Do Hyeon"으로 교체되었습니다.
	- HTML head에서 불필요한 메타데이터와 외부 리소스(파비콘, 설명, Kakao Maps SDK 등)가 제거되었습니다.

- **버그 수정**
	- 일부 API 요청이 잘못된 기본 URL로 연결되는 문제를 수정하였습니다.

- **기타**
	- 개발 서버 프록시 설정이 개선되어 환경 변수만을 사용하도록 변경되었습니다.
	- 프록시 보안 인증서 검증이 비활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->