### PR TITLE
[feat] 여행 계획 페이지 분할 UI 구현 및 카카오맵 렌더링 안정화

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -54,6 +54,12 @@ const routes = [
     path: '/:pathMatch(.*)*',
     redirect: '/',
   },
+  {
+    path: '/plans',
+    name: 'PlanPage',
+    component: () => import('@/views/PlanPage.vue'),
+    meta: { requiresAuth: true },
+  },
 ]
 
 const router = createRouter({

--- a/src/views/BoardEdit.vue
+++ b/src/views/BoardEdit.vue
@@ -5,16 +5,47 @@
       <div class="bg-white rounded-xl shadow p-6">
         <h1 class="text-2xl font-bold mb-6">게시글 수정</h1>
         <form @submit.prevent="submitEdit">
+          <!-- 제목 입력 -->
           <div class="mb-4">
             <label class="block mb-1 font-semibold">제목</label>
             <input v-model="title" type="text" class="w-full border rounded px-4 py-2" required />
           </div>
 
+          <!-- 내용 입력 -->
           <div class="mb-4">
             <label class="block mb-1 font-semibold">내용</label>
             <textarea v-model="content" class="w-full border rounded px-4 py-2 h-40" required />
           </div>
 
+          <!-- 기존 이미지 미리보기 및 삭제 -->
+          <div class="mb-4" v-if="existingImages.length">
+            <label class="block mb-1 font-semibold">기존 이미지</label>
+            <div class="grid grid-cols-2 gap-2">
+              <div
+                v-for="(img, index) in existingImages"
+                :key="index"
+                class="relative group border rounded overflow-hidden"
+              >
+                <img :src="img" class="object-cover h-40 w-full" />
+                <button
+                  type="button"
+                  @click="removeExistingImage(img)"
+                  class="absolute top-1 right-1 bg-white text-red-600 font-bold rounded-full w-6 h-6 flex items-center justify-center shadow hover:bg-red-100"
+                  title="이미지 삭제"
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <!-- 새 이미지 추가 -->
+          <div class="mb-4">
+            <label class="block mb-1 font-semibold">새 이미지 추가</label>
+            <input type="file" multiple @change="handleFiles" />
+          </div>
+
+          <!-- 제출 버튼 -->
           <div class="mt-6 flex justify-end">
             <button
               type="submit"
@@ -34,12 +65,32 @@ import { ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import axios from '@/api/axios'
 import Header from '@/components/Header.vue'
+import { useUserStore } from '@/stores/user'
+import { storeToRefs } from 'pinia'
+
+const userStore = useUserStore()
+const { nickname } = storeToRefs(userStore)
 
 const route = useRoute()
 const router = useRouter()
 
 const title = ref('')
 const content = ref('')
+const files = ref([]) // 새로 추가한 파일
+const existingImages = ref([]) // 기존 이미지 URL
+const removedImages = ref([]) // 제거된 기존 이미지 URL
+
+const handleFiles = (e) => {
+  const input = e.target
+  if (input.files) {
+    files.value = Array.from(input.files)
+  }
+}
+
+const removeExistingImage = (url) => {
+  existingImages.value = existingImages.value.filter((img) => img !== url)
+  removedImages.value.push(url)
+}
 
 const fetchPost = async () => {
   try {
@@ -49,32 +100,69 @@ const fetchPost = async () => {
       },
     })
     const post = res.data.data
+
+    if (post.writer !== nickname.value) {
+      alert('작성자만 수정할 수 있습니다.')
+      router.push(`/board/${route.params.id}`)
+      return
+    }
+
     title.value = post.title
     content.value = post.content
+    existingImages.value = post.imageUrls || []
   } catch (err) {
     alert('게시글 불러오기 실패')
     router.push('/board')
   }
 }
 
+// ⭐ 새 이미지 먼저 업로드
+const uploadNewImages = async () => {
+  if (files.value.length === 0) return []
+
+  const formData = new FormData()
+  files.value.forEach((file) => formData.append('images', file))
+
+  try {
+    const res = await axios.post('/api/image/upload', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+      },
+    })
+
+    return res.data.imageUrls || [] // 예: ['/images/1.png', '/images/2.png']
+  } catch (err) {
+    console.error('이미지 업로드 실패', err)
+    throw new Error('이미지 업로드 실패')
+  }
+}
+
 const submitEdit = async () => {
   try {
-    await axios.put(
-      `/api/board/${route.params.id}`,
-      {
-        title: title.value,
-        content: content.value,
+    // 1. 새 이미지 업로드
+    const newImageUrls = await uploadNewImages()
+
+    // 2. 기존 유지 이미지 + 새 이미지 병합
+    const finalImageUrls = [...existingImages.value, ...newImageUrls]
+
+    // 3. JSON 형태로 PUT 요청
+    const payload = {
+      title: title.value,
+      content: content.value,
+      imageUrls: finalImageUrls,
+    }
+
+    await axios.put(`/api/board/${route.params.id}`, payload, {
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
       },
-      {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-        },
-      }
-    )
+    })
 
     alert('수정 완료!')
     router.push(`/board/${route.params.id}`)
   } catch (err) {
+    console.error('수정 실패', err)
     alert('수정 실패!')
   }
 }

--- a/src/views/PlanPage.vue
+++ b/src/views/PlanPage.vue
@@ -1,0 +1,255 @@
+<template>
+  <div class="min-h-screen bg-gray-100">
+    <Header :alwaysLight="true" />
+
+    <!-- 수직 분할 가능한 컨테이너 -->
+    <div class="flex h-[calc(100vh-64px)] overflow-hidden">
+      <!-- 왼쪽 지도 영역 -->
+      <div :style="{ width: leftWidth + 'px' }" class="relative overflow-hidden">
+        <div id="map" class="w-full h-full"></div>
+        <div v-if="isLoading" class="loading-overlay">
+          <div class="loading-spinner">로딩 중...</div>
+        </div>
+        <div v-if="errorMessage" class="error-message">
+          {{ errorMessage }}
+        </div>
+      </div>
+
+      <!-- 사이 간격 조절 핸들 -->
+      <div
+        class="w-2 cursor-col-resize bg-gray-200 hover:bg-gray-400 transition"
+        @mousedown="startDragging"
+      ></div>
+
+      <!-- 오른쪽 여행 계획 작성 영역 -->
+      <div class="flex-1 bg-white p-6 overflow-y-auto">
+        <!-- 계획 입력 -->
+        <div>
+          <input
+            type="text"
+            v-model="plan.title"
+            class="w-full border px-4 py-2 rounded-lg mb-4 text-xl font-semibold"
+            placeholder="여행 제목을 입력하세요"
+          />
+          <div class="flex gap-4 mb-4">
+            <input
+              type="date"
+              v-model="plan.startDate"
+              class="border px-4 py-2 rounded-lg w-full"
+            />
+            <span class="self-center">~</span>
+            <input type="date" v-model="plan.endDate" class="border px-4 py-2 rounded-lg w-full" />
+          </div>
+          <textarea
+            v-model="plan.description"
+            class="w-full border rounded-lg px-4 py-2 min-h-[100px]"
+            placeholder="여행 소개를 적어보세요"
+          ></textarea>
+        </div>
+
+        <!-- 일자별 계획 -->
+        <div class="mt-8">
+          <div v-for="(day, index) in plan.days" :key="index" class="mb-6 border rounded-lg">
+            <div class="flex justify-between items-center bg-gray-50 px-4 py-3">
+              <div class="font-semibold text-lg">Day {{ index + 1 }} ({{ day.date }})</div>
+              <div class="flex gap-2">
+                <button @click="editDay(index)">✏️</button>
+                <button @click="removeDay(index)">🗑️</button>
+              </div>
+            </div>
+            <ul>
+              <li
+                v-for="(place, i) in day.places"
+                :key="i"
+                class="flex justify-between items-center px-4 py-2 border-t"
+              >
+                <div>
+                  <div class="font-medium">{{ place.name }}</div>
+                  <div class="text-sm text-gray-500">{{ place.time }}</div>
+                </div>
+                <div class="flex gap-2">
+                  <button @click="editPlace(index, i)">✏️</button>
+                  <button @click="removePlace(index, i)">🗑️</button>
+                </div>
+              </li>
+            </ul>
+            <button
+              class="w-full py-2 text-gray-500 hover:text-gray-800 border-t"
+              @click="addPlace(index)"
+            >
+              ➕ 장소 추가하기
+            </button>
+          </div>
+
+          <button
+            class="w-full py-3 border border-dashed rounded-lg text-gray-600 hover:bg-gray-100"
+            @click="addDay"
+          >
+            ➕ 새로운 일자 추가하기
+          </button>
+        </div>
+
+        <div class="flex justify-between mt-8">
+          <button
+            class="px-6 py-2 border border-blue-500 text-blue-600 rounded-lg hover:bg-blue-50"
+          >
+            미리보기
+          </button>
+          <button class="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
+            저장하기
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, onUnmounted, nextTick } from 'vue'
+import Header from '@/components/Header.vue'
+
+const plan = ref({
+  title: '서울 여행 계획',
+  startDate: '2025-06-15',
+  endDate: '2025-06-17',
+  description: '서울의 주요 관광지와 맛집을 탐방하는 여행입니다.',
+  days: [
+    {
+      date: '2025-06-15',
+      places: [
+        { name: '경복궁', time: '10:00 - 12:00' },
+        { name: '광화문 광장', time: '12:30 - 14:00' },
+        { name: '인사동', time: '14:30 - 16:30' },
+      ],
+    },
+    {
+      date: '2025-06-16',
+      places: [{ name: '남산타워', time: '10:00 - 12:00' }],
+    },
+    {
+      date: '2025-06-17',
+      places: [{ name: '한강공원', time: '10:00 - 13:00' }],
+    },
+  ],
+})
+
+// 지도 로딩 관련
+const mapContainer = ref(null)
+const map = ref(null)
+const isLoading = ref(false)
+const errorMessage = ref('')
+
+const leftWidth = ref(window.innerWidth * 0.6) // 60% = 3:2
+let isDragging = false
+
+const loadKakaoMapsScript = () => {
+  return new Promise((resolve) => {
+    if (window.kakao?.maps) {
+      resolve()
+      return
+    }
+    const script = document.createElement('script')
+    script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${import.meta.env.VITE_KAKAO_MAP_API_KEY}&autoload=false`
+    script.onload = () => {
+      window.kakao.maps.load(() => resolve())
+    }
+    script.onerror = () => {
+      errorMessage.value = '카카오맵 로드 실패'
+      resolve()
+    }
+    document.head.appendChild(script)
+  })
+}
+
+onMounted(async () => {
+  try {
+    isLoading.value = true
+    await loadKakaoMapsScript()
+    await nextTick()
+    const container = document.getElementById('map')
+    if (!container) throw new Error('지도 컨테이너 없음')
+    map.value = new window.kakao.maps.Map(container, {
+      center: new window.kakao.maps.LatLng(37.5665, 126.978),
+      level: 8,
+    })
+  } catch (err) {
+    console.error(err)
+    errorMessage.value = '지도 초기화 실패'
+  } finally {
+    isLoading.value = false
+  }
+})
+
+onUnmounted(() => {
+  if (map.value) {
+    map.value = null
+  }
+})
+
+const startDragging = (e) => {
+  isDragging = true
+  document.addEventListener('mousemove', onDrag)
+  document.addEventListener('mouseup', stopDragging)
+}
+
+const onDrag = (e) => {
+  if (isDragging) {
+    const min = 300
+    const max = window.innerWidth - 400
+    leftWidth.value = Math.min(Math.max(e.clientX, min), max)
+  }
+}
+
+const stopDragging = () => {
+  isDragging = false
+  document.removeEventListener('mousemove', onDrag)
+  document.removeEventListener('mouseup', stopDragging)
+
+  // ⭐ 지도 리사이즈 반영
+  if (map.value) {
+    window.kakao.maps.event.trigger(map.value, 'resize') // 이 방식도 됨
+    map.value.relayout() // 또는 이 방식으로 직접 강제 리레이아웃
+  }
+}
+
+const addDay = () => plan.value.days.push({ date: '', places: [] })
+const removeDay = (index) => plan.value.days.splice(index, 1)
+const addPlace = (dayIndex) =>
+  plan.value.days[dayIndex].places.push({ name: '새 장소', time: '시간 설정' })
+const removePlace = (dayIndex, placeIndex) => plan.value.days[dayIndex].places.splice(placeIndex, 1)
+const editDay = (index) => alert('Day 수정 예정')
+const editPlace = (dayIndex, placeIndex) => alert('장소 수정 예정')
+</script>
+
+<style scoped>
+#map {
+  width: 100%;
+  height: 100%;
+}
+.loading-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(255, 255, 255, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+.loading-spinner {
+  font-size: 1.2rem;
+  color: #333;
+}
+.error-message {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  background: #fdd;
+  color: #900;
+  padding: 6px 10px;
+  border-radius: 4px;
+  z-index: 20;
+}
+</style>

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -62,7 +62,7 @@
 
         <!-- 메인 콘텐츠 -->
         <main class="flex-1 space-y-6">
-          <!-- 내 정보 관리 섹션 -->
+          <!-- 프로필 정보 섹션 -->
           <section class="bg-white rounded-lg shadow p-6">
             <div class="flex items-center justify-between mb-4">
               <h2 class="text-2xl font-bold text-gray-800">내 정보 관리</h2>
@@ -93,23 +93,22 @@
             </form>
           </section>
 
-          <!-- 작성한 게시글 섹션 -->
+          <!-- 게시글 카드 형태 섹션 -->
           <section class="bg-white rounded-lg shadow p-6">
             <div class="mb-4">
               <h2 class="text-2xl font-bold text-gray-800">작성한 게시글</h2>
             </div>
-            <ul class="space-y-3">
-              <li
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div
                 v-for="post in userInfo.boards"
                 :key="post.id"
-                class="flex justify-between items-center"
+                class="p-4 bg-gray-50 rounded-lg shadow hover:shadow-md transition cursor-pointer"
+                @click="router.push(`/board/${post.id}`)"
               >
-                <router-link :to="`/posts/${post.id}`" class="text-gray-700 hover:text-indigo-600">
-                  {{ post.title }}
-                </router-link>
-                <span class="text-sm text-gray-500">{{ formatDate(post.createdAt) }}</span>
-              </li>
-            </ul>
+                <h3 class="text-lg font-semibold text-gray-800 mb-1">{{ post.title }}</h3>
+                <p class="text-sm text-gray-500">{{ formatDate(post.createdAt) }}</p>
+              </div>
+            </div>
           </section>
         </main>
       </div>

--- a/src/views/TravelHome.vue
+++ b/src/views/TravelHome.vue
@@ -203,7 +203,12 @@ import TypewriterText from '../components/TypewriterText.vue'
 const router = useRouter()
 
 const goLogin = () => {
-  router.push('/login')
+  const token = localStorage.getItem('accessToken')
+  if (token) {
+    router.push('/plans')
+  } else {
+    router.push('/login')
+  }
 }
 // 여기에서 문구들을 정의하세요.
 const typewriterTexts = [


### PR DESCRIPTION
## ✨ 주요 변경 사항
- 좌측 지도, 우측 계획 입력 화면을 수직 분할 구조로 구현
- 중앙 드래그 바를 통해 유동적인 비율 조정 가능
- 카카오맵 로딩 시점과 드래그 후 재렌더링 안정화
- 검색창 제거 및 단순화된 UI 구성 적용

## ✅ 상세 구현 내용
- `ref(leftWidth)` 기반으로 좌측 패널의 너비 상태 관리
- `@mousedown → @mousemove → @mouseup` 이벤트 흐름으로 드래그 처리
- 지도는 `onMounted`에서 `loadKakaoMapsScript` → `nextTick` → `new kakao.maps.Map(...)` 으로 생성
- `#map` ID로 명확한 컨테이너 참조
- `overflow-hidden`과 `height: 100%` 지정으로 레이아웃 오류 방지
- 여행 계획 입력란 (`title`, `date`, `description`, `days`) 구성
- `추가/삭제/수정` UI 버튼과 핸들링 메서드 모두 연결

---

## 📎 관련 이슈
- Closes #32 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 여행 계획 페이지가 추가되어, 지도와 여행 일정 편집 기능을 제공합니다.
  - 게시글 편집 시 이미지 추가, 미리보기, 삭제 및 업로드 기능이 지원됩니다.
  - 인증된 사용자만 접근 가능한 /plans 경로가 추가되었습니다.

- **UI 개선**
  - 프로필 페이지에서 작성한 게시글이 카드 형태의 그리드로 표시되어 가독성이 향상되었습니다.

- **버그 수정**
  - 여행 홈에서 로그인 버튼 클릭 시, 로그인 상태에 따라 /plans 또는 /login으로 이동하도록 동작이 개선되었습니다.

- **접근성 및 보안**
  - 게시글 편집 시 작성자 본인만 수정할 수 있도록 권한 검사가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->