### PR TITLE
[feat] 여행 계획 UI 리팩토링 및 지도 연동 로직 구현

### DIFF
--- a/src/components/KakaoMap.vue
+++ b/src/components/KakaoMap.vue
@@ -280,7 +280,7 @@ onMounted(async () => {
     // 지도 생성
     map.value = new window.kakao.maps.Map(mapContainer.value, {
       center: new window.kakao.maps.LatLng(37.5014, 127.0394),
-      level: 8,
+      level: 3,
     })
 
     isMapReady.value = true

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -32,13 +32,16 @@ const clearSearch = () => {
   searchKeyword.value = ''
 }
 
-// ✅ 초기 진입 시 쿼리로 받은 keyword 적용
+// 초기 진입 시 쿼리로 받은 keyword 적용
 onMounted(() => {
   const keywordFromQuery = route.query.keyword
-  if (keywordFromQuery && typeof keywordFromQuery === 'string') {
+  if (keywordFromQuery && typeof keywordFromQuery === 'string' && keywordFromQuery.trim()) {
     searchKeyword.value = keywordFromQuery
     selectedCategory.value = 'ALL'
-    handleSearchKeyword()
+    // 지도가 초기화된 후 검색 실행
+    nextTick(() => {
+      handleSearchKeyword()
+    })
   }
 })
 

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -1,11 +1,12 @@
 <script setup>
-import { ref, reactive } from 'vue'
+import { ref, reactive, onMounted } from 'vue'
 import KakaoMap from '@/components/KakaoMap.vue'
 import axios from '@/api/axios'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 
 // 상태 관리
 const router = useRouter()
+const route = useRoute() // ✅ 쿼리 수신
 const searchKeyword = ref('')
 const selectedCategory = ref(null)
 const selectedContentId = ref(null)
@@ -13,7 +14,7 @@ const attractionList = ref([])
 const kakaoMapRef = ref(null)
 
 const categories = reactive([
-  { id: 'ALL', name: '전체', icon: '🌍' }, // 🚨 전체 카테고리 추가
+  { id: 'ALL', name: '전체', icon: '🌍' },
   { id: 'A01', name: '자연', icon: '🌳' },
   { id: 'A02', name: '문화', icon: '🏯' },
   { id: 'A03', name: '레포츠', icon: '🚵' },
@@ -31,19 +32,24 @@ const clearSearch = () => {
   searchKeyword.value = ''
 }
 
-// 🚨 카테고리 선택 (전체 포함)
+// ✅ 초기 진입 시 쿼리로 받은 keyword 적용
+onMounted(() => {
+  const keywordFromQuery = route.query.keyword
+  if (keywordFromQuery && typeof keywordFromQuery === 'string') {
+    searchKeyword.value = keywordFromQuery
+    selectedCategory.value = 'ALL'
+    handleSearchKeyword()
+  }
+})
+
+// 카테고리 선택
 const selectCategory = (category) => {
   if (selectedCategory.value === category.id) {
-    // 카테고리 해제
     selectedCategory.value = null
     searchKeyword.value = ''
-    // if (kakaoMapRef.value) {
-    //   kakaoMapRef.value.renderAttractions([])
-    // }
     updateAttractions([])
     console.log('카테고리 선택 해제')
   } else {
-    // 카테고리 선택
     selectedCategory.value = category.id
     searchKeyword.value = category.name
     console.log(`"${category.name}" 카테고리 선택됨. 현 지도에서 검색 버튼을 눌러주세요.`)
@@ -56,14 +62,11 @@ const updateAttractions = (items) => {
 
 const onAttractionClick = (attraction) => {
   selectedContentId.value = attraction.contentId
-  if (kakaoMapRef.value) {
-    kakaoMapRef.value.focusMarker(attraction.contentId)
-  }
+  kakaoMapRef.value?.focusMarker(attraction.contentId)
 }
 
-// 🚨 수정된 메인 검색 함수 - 전체 검색 지원
+// 지도에서 관광지 데이터 요청
 const requestMarkers = async () => {
-  // 현재 지도 정보 가져오기
   if (!kakaoMapRef.value) {
     alert('지도가 준비되지 않았습니다.')
     return
@@ -75,17 +78,7 @@ const requestMarkers = async () => {
     return
   }
 
-  const { level, bounds } = mapInfo
-
-  // // 레벨 체크
-  // if (level > 12) {
-  //   alert('지도를 더 확대해주세요. (현재 너무 멀리 보고 있습니다)')
-  //   console.log(`🔕 레벨 ${level} → 너무 멀어 검색 취소`)
-  //   updateAttractions([])
-  //   kakaoMapRef.value.renderAttractions([])
-  //   return
-  // }
-
+  const { bounds } = mapInfo
   const sw = bounds.sw
   const ne = bounds.ne
 
@@ -96,44 +89,23 @@ const requestMarkers = async () => {
     let apiUrl = ''
     let attractions = []
 
-    // 🚨 카테고리에 따른 API 호출 분기
     if (!selectedCategory.value || selectedCategory.value === 'ALL') {
-      // 전체 검색 - 새로운 API 사용
       apiUrl = `/api/map?swLatLng=${sw.lat},${sw.lng}&neLatLng=${ne.lat},${ne.lng}`
-      console.log('📡 전체 검색 API 호출:', apiUrl)
-
       const { data } = await axios.get(apiUrl)
-      if (!data?.data?.attractions) {
-        throw new Error('서버 응답이 올바르지 않습니다')
-      }
-      attractions = data.data.attractions
+      attractions = data?.data?.attractions || []
     } else {
-      // 카테고리별 검색 - 기존 API 사용
       apiUrl = `/api/map/category/${selectedCategory.value}`
-      console.log('📡 카테고리별 검색 API 호출:', apiUrl)
-
       const { data } = await axios.get(apiUrl)
-      if (!data?.data?.attractions) {
-        throw new Error('서버 응답이 올바르지 않습니다')
-      }
-      attractions = data.data.attractions
-
-      // 현 지도 범위 안에 있는 항목만 필터링 (카테고리별 검색일 때만)
-      attractions = attractions.filter((item) => {
-        if (!item.latitude || !item.longitude || isNaN(item.latitude) || isNaN(item.longitude)) {
+      attractions = (data?.data?.attractions || []).filter((item) => {
+        if (!item.latitude || !item.longitude || isNaN(item.latitude) || isNaN(item.longitude))
           return false
-        }
-
         const lat = Number(item.latitude)
         const lng = Number(item.longitude)
-
         return lat >= sw.lat && lat <= ne.lat && lng >= sw.lng && lng <= ne.lng
       })
     }
 
     console.log(`✅ 검색 완료: ${attractions.length}개 발견`)
-
-    // 지도 & 리스트 업데이트
     updateAttractions(attractions)
     kakaoMapRef.value.renderAttractions(attractions)
 
@@ -146,15 +118,12 @@ const requestMarkers = async () => {
   }
 }
 
-// 🚨 수정된 검색창 처리 - 카테고리 없이도 가능
+// 검색창 엔터 or 버튼 클릭 시 실행
 const handleSearchKeyword = () => {
   if (!searchKeyword.value.trim()) {
-    // 검색어가 없으면 전체 검색으로 처리
     selectedCategory.value = 'ALL'
     searchKeyword.value = '전체'
   }
-
-  // 검색 실행
   requestMarkers()
 }
 </script>

--- a/src/views/PlanPage.vue
+++ b/src/views/PlanPage.vue
@@ -154,17 +154,17 @@ const categories = [
   { id: 'A04', name: '쇼핑', icon: '🏱' },
   { id: 'A05', name: '식당', icon: '🍽️' },
   { id: 'B02', name: '숙박', icon: '🏨' },
-  { id: 'C01', name: '추천코스', icon: '💯' },
 ]
 
 const handleSearchKeyword = () => {
   if (!searchKeyword.value.trim()) return
+  selectedCategory.value = null // 카테고리 선택 초기화
   requestMarkers()
 }
 
 const selectCategory = (category) => {
   selectedCategory.value = category.id
-  searchKeyword.value = category.name
+  searchKeyword.value = '' // 검색어 초기화
   requestMarkers()
 }
 
@@ -186,6 +186,8 @@ const requestMarkers = async () => {
     kakaoMapRef.value.renderAttractions(attractions)
   } catch (e) {
     console.error('마커 요청 실패', e)
+    // 사용자에게 오류 알림
+    alert('마커를 불러오는데 실패했습니다. 다시 시도해주세요.')
   }
 }
 

--- a/src/views/TravelHome.vue
+++ b/src/views/TravelHome.vue
@@ -20,11 +20,14 @@
       <div class="w-full max-w-md flex flex-col gap-3">
         <div class="relative">
           <input
+            v-model="searchKeyword"
             type="text"
             placeholder="어디로 여행을 떠나시나요?"
             class="w-full px-4 py-3 rounded-md shadow-md text-gray-800"
           />
-          <button class="absolute right-3 top-1/2 -translate-y-1/2 text-xl">🔍</button>
+          <button @click="goSearch" class="absolute right-3 top-1/2 -translate-y-1/2 text-xl">
+            🔍
+          </button>
         </div>
         <button
           @click="goLogin"
@@ -196,11 +199,23 @@
 </template>
 
 <script setup>
+import { ref } from 'vue'
 import Header from '../components/Header.vue'
 import { useRouter } from 'vue-router'
 import TypewriterText from '../components/TypewriterText.vue'
 
 const router = useRouter()
+
+const searchKeyword = ref('')
+
+const goSearch = () => {
+  if (searchKeyword.value.trim()) {
+    router.push({
+      path: '/map',
+      query: { keyword: searchKeyword.value.trim() },
+    })
+  }
+}
 
 const goLogin = () => {
   const token = localStorage.getItem('accessToken')


### PR DESCRIPTION
### 주요 변경 사항

- 여행 계획 작성 화면 좌우 분할 구조로 개선
- 지도 영역 비율 조절 기능 (`mousedown + mousemove + mouseup` 기반 핸들)
- 카카오맵 SDK 비동기 로딩 후 지도 초기화 처리 (`window.kakao.maps.load`)
- 계획 입력 영역: 제목, 일정, 설명, Day별 장소 리스트 UI 구현
- 지도 리사이즈 대응 로직 (`map.relayout()` + `event.trigger`)
- 계획 데이터는 현재 mock 데이터로 구성되며, 후속 작업으로 저장/불러오기/AI 연동 예정

### 구현 구조 요약

| 영역 | 설명 |
|------|------|
| 좌측 | 카카오 지도 (`#map`) 영역 |
| 우측 | 계획 작성 UI (title, date, day/places 등) |
| 가운데 | 사이즈 조절 핸들 구현 (min/max 제한) |

### 추후 작업 예정
- AI 기반 추천 장소 추가 컴포넌트 삽입
- 경로 추천 API와의 통합 작업
- 실제 저장/수정/삭제 API 연동 및 로컬 캐시 처리

---

Close #35 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 홈 화면에서 여행지 검색 시, 입력한 키워드로 지도 페이지로 이동하여 자동 검색이 실행됩니다.
  - 지도 페이지에서 URL 쿼리 파라미터로 검색어를 받아 초기 검색이 가능합니다.
  - 플랜 페이지에 카테고리 필터, 검색 입력창, 새로고침 버튼이 추가되어 지도에서 원하는 장소를 쉽게 찾을 수 있습니다.

- **개선사항**
  - 지도 초기 확대 레벨이 변경되어 더 가까운 위치에서 지도가 시작됩니다.
  - 지도 및 플랜 페이지의 카테고리 선택 및 검색 흐름이 간소화되고, 마커 표시가 더 안정적으로 동작합니다.
  - 플랜 페이지의 지도 기능이 별도 컴포넌트로 분리되어 UI와 사용성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->